### PR TITLE
Update PostCSS minimum version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "15.1.3",
-        "postcss": "^8",
+        "postcss": ">=8.5.10",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "15.1.3",
-    "postcss": "^8",
+    "postcss": ">=8.5.10",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Summary
- Update the direct PostCSS dependency range to require >=8.5.10
- Keep package-lock.json aligned with the manifest

## Verification
- npm install
- npm ls postcss --depth=0

Note: npm run lint currently fails because the Next CLI treats 'lint' as a project directory argument in this setup.